### PR TITLE
STY: migrate from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,17 +26,16 @@ repos:
     hooks:
       - id: setup-cfg-fmt
 
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.6.0
+    hooks:
+      - id: reorder-python-imports
+
   - repo: https://github.com/psf/black
     rev: 21.7b0
     hooks:
       - id: black
         language_version: python3
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
-    hooks:
-      - id: isort
-        additional_dependencies: [toml]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![codecov](https://codecov.io/gh/neutrinoceros/inifix/branch/main/graph/badge.svg)](https://codecov.io/gh/neutrinoceros/inifix)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/neutrinoceros/inifix/main.svg)](https://results.pre-commit.ci/badge/github/neutrinoceros/inifix/main.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 
 
 `inifix` in a small Python library with I/O methods to read and write

--- a/inifix/__init__.py
+++ b/inifix/__init__.py
@@ -1,4 +1,5 @@
-from .io import dump, load
+from .io import dump
+from .io import load
 from .validation import validate_inifile_schema
 
 __version__ = "0.5.1"

--- a/inifix/_typing.py
+++ b/inifix/_typing.py
@@ -1,5 +1,8 @@
 import os
-from typing import Iterable, Mapping, TypeVar, Union
+from typing import Iterable
+from typing import Mapping
+from typing import TypeVar
+from typing import Union
 
 T = TypeVar("T")
 Scalar = Union[int, float, bool, str]

--- a/inifix/format.py
+++ b/inifix/format.py
@@ -2,7 +2,8 @@ import argparse
 import os
 import re
 import sys
-from typing import Optional, Sequence
+from typing import Optional
+from typing import Sequence
 
 from inifix.io import load
 

--- a/inifix/iniconf.py
+++ b/inifix/iniconf.py
@@ -2,11 +2,20 @@ import re
 from collections import defaultdict
 from functools import singledispatchmethod
 from io import TextIOBase
-from typing import Callable, List, TextIO, Tuple, Union
+from typing import Callable
+from typing import List
+from typing import TextIO
+from typing import Tuple
+from typing import Union
 
-from more_itertools import always_iterable, mark_ends
+from more_itertools import always_iterable
+from more_itertools import mark_ends
 
-from inifix._typing import InifixParsable, IterableOrSingle, PathLike, Scalar, Section
+from inifix._typing import InifixParsable
+from inifix._typing import IterableOrSingle
+from inifix._typing import PathLike
+from inifix._typing import Scalar
+from inifix._typing import Section
 from inifix.enotation import ENotationIO
 from inifix.validation import validate_inifile_schema
 

--- a/inifix/io.py
+++ b/inifix/io.py
@@ -1,4 +1,5 @@
-from typing import TextIO, Union
+from typing import TextIO
+from typing import Union
 
 from inifix._typing import PathLike
 from inifix.iniconf import InifixConf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,6 @@ requires = ["setuptools", "wheel"]
 [tool.black]
 line-length = 88
 
-[tool.isort]
-profile = "black"
-combine_as_imports = true
-
 [tool.pytest.ini_options]
 # pytest looks for configuration from pyproject.toml
 # only from version 6.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 from setuptools import setup
 
 setup()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -6,7 +6,8 @@ from stat import S_IREAD
 import pytest
 
 from inifix import load
-from inifix.format import iniformat, main
+from inifix.format import iniformat
+from inifix.format import main
 
 
 @pytest.mark.parametrize("flag", ["-i", "--inplace"])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import pytest
 
-from inifix.io import dump, load
+from inifix.io import dump
+from inifix.io import load
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,7 +1,8 @@
 import pytest
 from more_itertools import unzip
 
-from inifix.io import dump, load
+from inifix.io import dump
+from inifix.io import load
 from inifix.validation import validate_inifile_schema
 
 INVADLID_SCHEMAS, INVALID_SCHEMAS_IDS = unzip(


### PR DESCRIPTION
identical to #64, for the main branch