### PR TITLE
BUG: pretty pring warnings from iniformat so they don't look as bad from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2022-01-04
+
+BUG: pretty print warnings from iniformat so they don't look as bad from the CLI
+[PR #89](https://github.com/neutrinoceros/inifix/pull/89)
+
 ## [0.11.0] - 2022-01-04
 
 ENH: replace `--inplace` option in `inifix-format` with a `--diff` option

--- a/inifix/__init__.py
+++ b/inifix/__init__.py
@@ -2,4 +2,4 @@ from .io import dump
 from .io import load
 from .validation import validate_inifile_schema
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/inifix/format.py
+++ b/inifix/format.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import re
 import sys
-import warnings
 from difflib import unified_diff
 from typing import Optional
 from typing import Sequence
@@ -61,11 +60,14 @@ def iniformat(data: str, *, name_column_size: Optional[int] = None) -> str:
 
         if max_name_size >= name_column_size:
             long_parameters = [p for p in parameters if len(p) >= name_column_size]
-            warnings.warn(
-                "The following parameters\n"
-                + "\n".join(long_parameters)
-                + f"\nare longer than user specified column length ({name_column_size}). "
-                + "Column length will be adjusted regardless.",
+            print(
+                "WARNING: The following names are longer than the "
+                f"specified name column size ({name_column_size}).\n"
+                + " - "
+                + "\n - ".join(long_parameters)
+                + "\n"
+                + "Additional whitespace will be used.",
+                file=sys.stderr,
             )
 
     new_lines = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inifix
-version = 0.11.0
+version = 0.11.1
 description = I/O facility for Idefix/Pluto configuration files
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -91,7 +91,6 @@ def test_exact_format_inplace(capsys, tmp_path):
 
 
 @pytest.mark.parametrize("size", ["10", "20", "50"])
-@pytest.mark.filterwarnings(r"ignore:^The following parameters\n")
 def test_exact_format_with_column_size_flag(size, capsys, tmp_path):
     DATA_DIR = Path(__file__).parent / "data"
     target = tmp_path / "out.ini"
@@ -100,7 +99,7 @@ def test_exact_format_with_column_size_flag(size, capsys, tmp_path):
     ret = main([str(target), "--name-column-size", size])
     out, err = capsys.readouterr()
 
-    assert err == f"Fixing {target}\n"
+    assert f"Fixing {target}\n" in err
     assert ret != 0
 
     expected = (DATA_DIR / f"format-column-size-out-{size}.ini").read_text()


### PR DESCRIPTION
fix #88

```
$ inifix-format tests/data/format-column-size-in.ini --name-column-size=5
WARNING: The following names are longer than the specified name column size (5).
 - dummy
 - thisparameternameshouldprobablybeshorter
 - thisoneisshorter
 - faultyTowers
 - param
Additional whitespace will be used.
Fixing tests/data/format-column-size-in.ini
```