### PR TITLE
ENH: add support for binary IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2022-05-01
+
+ENH: add support for binary IO
+
+All internal IO operations are now performed in binary mode whenever possible, assuming
+UTF-8 encoding.
+
 ## [2.2.1] - 2022-04-30
 
 BUG: fix a regression (inifix 2.2.0) where inifix.dump was able to write to a file even if

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `inifix`
 
 [![PyPI](https://img.shields.io/pypi/v/inifix.svg?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/inifix/)
-[![PyPI](https://img.shields.io/pypi/pyversions/inifix/2.2.1?logo=python&logoColor=white&label=Python)](https://pypi.org/project/inifix/)
+[![PyPI](https://img.shields.io/pypi/pyversions/inifix/2.3.0?logo=python&logoColor=white&label=Python)](https://pypi.org/project/inifix/)
 [![codecov](https://codecov.io/gh/neutrinoceros/inifix/branch/main/graph/badge.svg)](https://codecov.io/gh/neutrinoceros/inifix)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/neutrinoceros/inifix/main.svg)](https://results.pre-commit.ci/badge/github/neutrinoceros/inifix/main.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -108,12 +108,13 @@ and consists in four main functions:
 ```python
 import inifix
 
-with open("pluto.ini") as fh:
+with open("pluto.ini, "rb") as fh:
     conf = inifix.load(fh)
 
 # or equivalently
 conf = inifix.load("pluto.ini")
 ```
+Files are assumed to be encoded as UTF-8.
 
 ### ... and writing back to disk
 
@@ -123,9 +124,15 @@ This allows to change a value on the fly and create new
 configuration files programmatically, for instance.
 ```python
 conf["Time"]["CFL"] = 0.1
+
+with open("pluto-mod.ini", "wb") as fh:
+    inifix.dump(conf, fh)
+
+# or equivalently
 inifix.dump(conf, "pluto-mod.ini")
 ```
 Data will be validated against inifix's format specification at write time.
+Files are always encoded as UTF-8.
 
 ### Schema Validation
 
@@ -153,7 +160,7 @@ This simple validator can be used as a hook for `pre-commit`. Simply add the
 following to your project's `.pre-commit-config.yaml`
 ```yaml
   - repo: https://github.com/neutrinoceros/inifix.git
-    rev: v2.2.1
+    rev: v2.3.0
     hooks:
       - id: inifix-validate
 ```
@@ -164,7 +171,10 @@ To format a file in place, use
 ```shell
 $ inifix-format pluto.ini
 ```
-Note that comments are preserved.
+inifix-format is guaranteed to preserve comments and to *only* edit (add or remove)
+whitespace characters.
+
+Files are always encoded as UTF-8.
 
 #### Options
 
@@ -178,7 +188,7 @@ $ inifix-format pluto.ini --diff
 This program also doubles as `pre-commit` hook
 ```yaml
   - repo: https://github.com/neutrinoceros/inifix.git
-    rev: v2.2.1
+    rev: v2.3.0
     hooks:
       - id: inifix-format
 ```

--- a/inifix/__init__.py
+++ b/inifix/__init__.py
@@ -4,4 +4,4 @@ from .io import load
 from .io import loads
 from .validation import validate_inifile_schema
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"

--- a/inifix/_typing.py
+++ b/inifix/_typing.py
@@ -6,6 +6,9 @@ from typing import Iterable
 from typing import TypeVar
 from typing import Union
 
+# not quite typing.AnyStr : this is not a constrained type variable
+StrLike = Union[str, bytes]
+
 if sys.version_info >= (3, 9):
     PathLike = Union[AnyStr, os.PathLike[AnyStr]]
 else:

--- a/inifix/format.py
+++ b/inifix/format.py
@@ -139,8 +139,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             retv = 1
             continue
 
-        with open(file) as fh:
-            data = fh.read()
+        with open(file, mode="rb") as fh:
+            data = fh.read().decode("utf-8")
+            # make sure newlines are always decoded as \n, even on windows
+            data = data.replace("\r\n", "\n")
 
         fmted_data = iniformat(data)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = inifix
-version = 2.2.1
+version = 2.3.0
 description = I/O facility for Idefix/Pluto configuration files
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -37,7 +37,7 @@ console_scripts =
 dev =
     pytest>=6.1
 typecheck =
-    mypy==0.931
+    mypy==0.950
 
 [options.package_data]
 inifix =

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -166,3 +166,13 @@ def test_format_quoted_strings_with_whitespaces(tmp_path):
     assert ret != 0
 
     assert target.read_text() == expected
+
+
+def test_data_preservation(inifile, tmp_path):
+    # check that perilous string manipulations do not destroy data
+    initial_mapping = load(inifile)
+    target = tmp_path / inifile.name
+    shutil.copyfile(inifile, target)
+    main([str(target)])
+    round_mapping = load(target)
+    assert round_mapping == initial_mapping


### PR DESCRIPTION
Fix #111

TODO:
- [x] implement inifix.dump to binary io
- [x] use binary io as often as possible internally
- [x] document (docstrings) that everything is encoded as utf-8 
- [x] implem binary input for iniformat
- [x] bump version