### PR TITLE
PERF: optimize parsing speed

### DIFF
--- a/inifix/io.py
+++ b/inifix/io.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import re
-from copy import deepcopy
 from io import BufferedIOBase, IOBase
 from typing import Any, Callable, Literal, Mapping, cast
 
@@ -68,13 +67,9 @@ class Section(dict):
         if not isinstance(k, str):
             raise TypeError(f"Expected str keys. Received invalid key: {k}")
 
-        _val = deepcopy(v)  # avoid consuming the original iterable
         if not (
             isinstance(v, SCALAR_TYPES)
-            or (
-                isinstance(_val, list)
-                and all(isinstance(_, SCALAR_TYPES) for _ in _val)
-            )
+            or (isinstance(v, list) and all(isinstance(_, SCALAR_TYPES) for _ in v))
         ):
             raise TypeError(
                 "Expected all values to be scalars or lists of scalars. "

--- a/inifix/io.py
+++ b/inifix/io.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from functools import partial
 from io import BufferedIOBase, IOBase
 from typing import Any, Callable, Literal, Mapping, cast
 
@@ -88,6 +89,10 @@ class Section(dict):
 # load helper functions
 
 
+# this is more efficient than running str.partition in a loop
+_SPLIT_COMMENTS = partial(str.split, sep="#", maxsplit=1)
+
+
 def _normalize_data(data: StrLike) -> list[str]:
     # normalize text body `data` to parsable text lines
     out_lines: list[str] = []
@@ -96,10 +101,8 @@ def _normalize_data(data: StrLike) -> list[str]:
     else:
         raw_lines = data.splitlines()
 
-    for line in raw_lines:
-        # remove comments and normalize whitespace
-        line, _, _comment = line.partition("#")
-        out_lines.append(re.sub(r"\s", " ", line.strip()))
+    out_lines.extend([line.strip() for (line, *_) in map(_SPLIT_COMMENTS, raw_lines)])
+
     return out_lines
 
 

--- a/inifix/io.py
+++ b/inifix/io.py
@@ -138,6 +138,9 @@ def _split_tokens(data: str) -> list[str]:
     return tokens
 
 
+_TRAILLING_NUM = re.compile(r"\.0+$")
+
+
 def _tokenize_line(
     line: str, line_number: int, filename: str | None
 ) -> tuple[str, list[Scalar]]:
@@ -151,16 +154,18 @@ def _tokenize_line(
     values = []
     for val in raw_values:
         # remove period and trailing zeros to cast to int when possible
-        val = re.sub(r"\.0+$", "", val)
+        val = _TRAILLING_NUM.sub("", val)
 
         for caster in CASTERS:
             # cast to types from stricter to most permissive
             # `str` will always succeed since it is the input type
             try:
-                values.append(caster(val))
-                break
+                _casted = caster(val)
             except ValueError:
                 continue
+            else:
+                values.append(_casted)
+                break
 
     return key, values
 

--- a/inifix/io.py
+++ b/inifix/io.py
@@ -108,8 +108,11 @@ def _normalize_data(data: StrLike) -> list[str]:
 
 def _next_token(data: str, pattern: str, start: Literal[0, 1]) -> tuple[str, int]:
     pos: int = start
-    while pos < len(data) and not re.match(pattern, data[pos]):
-        pos += 1
+    match = re.search(pattern, data[start:])
+    if match is not None:
+        pos = start + match.start()
+    else:
+        pos = len(data)
     if start == 1:
         end = pos + 1
     else:

--- a/inifix/io.py
+++ b/inifix/io.py
@@ -106,9 +106,11 @@ def _normalize_data(data: StrLike) -> list[str]:
     return out_lines
 
 
-def _next_token(data: str, pattern: str, start: Literal[0, 1]) -> tuple[str, int]:
+def _next_token(
+    data: str, pattern: re.Pattern, start: Literal[0, 1]
+) -> tuple[str, int]:
     pos: int = start
-    match = re.search(pattern, data[start:])
+    match = pattern.search(data[start:])
     if match is not None:
         pos = start + match.start()
     else:
@@ -121,9 +123,14 @@ def _next_token(data: str, pattern: str, start: Literal[0, 1]) -> tuple[str, int
     return token, pos
 
 
+_SPACES = re.compile(r"\s")
+_SINGLE_QUOTE = re.compile("'")
+_DOUBLE_QUOTE = re.compile('"')
+
+
 def _split_tokens(data: str) -> list[str]:
     tokens = []
-    pattern = r"\s"
+    pattern = _SPACES
     start: Literal[0, 1] = 0
     data = data.strip()
     while True:
@@ -132,11 +139,15 @@ def _split_tokens(data: str) -> list[str]:
         data = data[pos + 1 :].strip()
         if not data:
             break
-        if data[0] in ('"', "'"):
-            pattern = data[0]
+        d0 = data[0]
+        if _SINGLE_QUOTE.match(d0):
+            pattern = _SINGLE_QUOTE
+            start = 1
+        elif _DOUBLE_QUOTE.match(d0):
+            pattern = _DOUBLE_QUOTE
             start = 1
         else:
-            pattern = r"\s"
+            pattern = _SPACES
             start = 0
     return tokens
 

--- a/inifix/io.py
+++ b/inifix/io.py
@@ -179,7 +179,7 @@ def _from_string(
     for line_number, line in enumerate(lines, start=1):
         if not line:
             continue
-        match = re.fullmatch(SECTION_REGEXP, line)
+        match = SECTION_REGEXP.fullmatch(line)
         if match is not None:
             if section:
                 section._dump_to(container)

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -1,7 +1,7 @@
 import pytest
 
 import inifix
-from inifix.io import bool_caster
+from inifix.io import _RE_CASTERS
 
 BASE_BOOLS = [
     ("True", True),
@@ -15,15 +15,20 @@ BASE_BOOLS = [
 ]
 
 
+def autocast(v):
+    for regexp, caster in _RE_CASTERS:
+        if regexp.fullmatch(v):
+            return caster(v)
+
+
 @pytest.mark.parametrize("s, expected", BASE_BOOLS)
 def test_bool_cast(s, expected):
-    assert bool_caster(s) is expected
+    assert autocast(s) is expected
 
 
 @pytest.mark.parametrize("s", ["tdsk", "1213", "Treu", "Flsae", "flkj"])
 def test_bool_cast_invalid(s):
-    with pytest.raises(ValueError):
-        bool_caster(s)
+    assert type(autocast(s)) is not bool
 
 
 @pytest.mark.parametrize("s, expected", BASE_BOOLS)


### PR DESCRIPTION
benchmarked with the following script

```python
# benchmark.py
from time import monotonic_ns
import inifix

tstart = monotonic_ns()
for i in range(1000):
    inifix.load("tests/data/idefix-ShearingBox.ini", skip_validation=True)

tstop = monotonic_ns()
print(f"{(tstop-tstart)/1e6:.1f} ms")
```
I get about 520 ms on `main` and 225 ms on this branch. 


Hotspots were detected using the following commands to generate reports
```shell
python -m cProfile -o log.pstats benchmark.py && gprof2dot --colour-nodes-by-selftime log.pstats | dot -Tsvg -o out.svg
```
and
```shell
scale benchmark.py
```

Startup time is not affected.