### PR TITLE
BUG: fix a regression where signed floats were interpreted as strings

### DIFF
--- a/inifix/io.py
+++ b/inifix/io.py
@@ -134,7 +134,7 @@ _RE_CASTERS: list[tuple[re.Pattern, Callable[[str], Any]]] = [
     (re.compile(r"[0-9]+"), int),
     (
         re.compile(
-            r"(?:((?:\d\.?\d*[Ee][+\-]?\d+)|(?:\d+\.\d*|\d*\.\d+))|\d+|inf\s|nan\s)"
+            r"[+/-]?(?:((?:\d\.?\d*[Ee][+\-]?\d+)|(?:\d+\.\d*|\d*\.\d+))|\d+|inf\s|nan\s)"
         ),
         float,
     ),

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -37,3 +37,23 @@ def test_bool_cast_integration(s, expected, tmp_path):
         fh.write(f"dummy {s}")
     d = inifix.load(tmp_path / "dummy.ini")
     assert d == {"dummy": expected}
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        ("1.", 1.0),
+        ("1.0", 1.0),
+        ("1e3", 1000.0),
+        ("+1.", 1.0),
+        ("+1.0", 1.0),
+        ("+1e3", 1000.0),
+        ("-1.", -1.0),
+        ("-1.0", -1.0),
+        ("-1e3", -1000.0),
+    ],
+)
+def test_float_cast(s, expected):
+    res = autocast(s)
+    assert type(res) is float
+    assert res == expected


### PR DESCRIPTION
this is a regression in inifix 4.2