### PR TITLE
ENH: add support for type-checking inifix.load's return value

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,4 +113,4 @@ jobs:
         python -m pip install .
 
     - name: Run mypy
-      run: mypy src/inifix
+      run: mypy src/inifix tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+ENH: add support for type-checking return values from `inifix.load` and `inifix.loads`
+
 ## [4.3.2] - 2023-03-11
 
 BUG: fix type casting bugs affecting integers and strings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,8 @@ disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"
-ignore_errors = true
+#ignore_errors = true
+disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,1 +1,2 @@
 mypy==1.5.1
+pytest

--- a/src/inifix/io.py
+++ b/src/inifix/io.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Mapping
 from functools import partial
 from io import BufferedIOBase, IOBase
-from typing import Any, Callable, cast
+from typing import Any, Callable, TypeVar, cast, overload
 
 from more_itertools import always_iterable, mark_ends
 
@@ -219,13 +219,43 @@ def _write_to_file(data: InifixConfT, file: PathLike, /) -> None:
         os.replace(tmpfile, file)
 
 
+_RT = TypeVar("_RT")
+
+
+@overload
 def load(
     source: InifixConfT | PathLike | IOBase,
     /,
     *,
     parse_scalars_as_lists: bool = False,
     skip_validation: bool = False,
+    return_type: type[_RT],
+) -> _RT:
+    # the user is responsible for defining the return type and verifying that
+    # the result conforms to the definition
+    ...
+
+
+@overload
+def load(
+    source: InifixConfT | PathLike | IOBase,
+    /,
+    *,
+    parse_scalars_as_lists: bool = False,
+    skip_validation: bool = False,
+    return_type: None = None,
 ) -> InifixConfT:
+    ...
+
+
+def load(  #  type: ignore[no-untyped-def]
+    source,
+    /,
+    *,
+    parse_scalars_as_lists=False,
+    skip_validation=False,
+    return_type=None,
+):
     """
     Parse data from a file, or a dict.
 
@@ -246,6 +276,11 @@ def load(
         if set to True, input is not validated. This can be used to speedup io operations
         trusted input or to work around bugs with the validation routine. Use with caution.
 
+    return_type: Python type, or None (default)
+       this argument enables type-checking user code by specifying the expected return
+       type. Note that this has no effect at runtime. The user is responsible for
+       any runtime validation.
+
     See Also
     --------
     inifix.loads
@@ -265,13 +300,40 @@ def load(
     return source
 
 
+@overload
 def loads(
     source: str,
     /,
     *,
     parse_scalars_as_lists: bool = False,
     skip_validation: bool = False,
+    return_type: type[_RT],
+) -> _RT:
+    # the user is responsible for defining the return type and verifying that
+    # the result conforms to the definition
+    ...
+
+
+@overload
+def loads(
+    source: str,
+    /,
+    *,
+    parse_scalars_as_lists: bool = False,
+    skip_validation: bool = False,
+    return_type: None = None,
 ) -> InifixConfT:
+    ...
+
+
+def loads(  #  type: ignore[no-untyped-def]
+    source,
+    /,
+    *,
+    parse_scalars_as_lists=False,
+    skip_validation=False,
+    return_type=None,
+):
     """
     Parse data from a string.
 
@@ -288,6 +350,10 @@ def loads(
         if set to True, input is not validated. This can be used to speedup io operations
         trusted input or to work around bugs with the validation routine. Use with caution.
 
+    return_type: Python type, or None (default)
+       this argument enables type-checking user code by specifying the expected return
+       type. Note that this has no effect at runtime. The user is responsible for
+       any runtime validation.
     See Also
     --------
     inifix.load

--- a/tests/test_file_validation.py
+++ b/tests/test_file_validation.py
@@ -20,7 +20,7 @@ INVALID_CONTENTS, INVALID_CONTENTS_IDS = unzip(
 )
 
 
-@pytest.fixture(params=INVALID_CONTENTS, ids=INVALID_CONTENTS_IDS)
+@pytest.fixture(params=INVALID_CONTENTS, ids=INVALID_CONTENTS_IDS)  # type: ignore[call-overload]
 def invalid_file(tmp_path, request):
     file = tmp_path / "myfile.ini"
     file.write_text(request.param)

--- a/tests/test_load_typing.py
+++ b/tests/test_load_typing.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+from typing import TypedDict
+
+import pytest
+
+import inifix
+
+DATA_DIR = Path(__file__).parent / "data"
+
+
+def test_return_type() -> None:
+    # this is mostly a textbook example of the expected usage of `return_type`
+    class DummySection(TypedDict):
+        x: int
+        y: int
+        z: int
+        origin: list[int]
+        fast: bool
+        pi: float
+        timestep: float
+
+    class Expected(TypedDict):
+        Dummy: DummySection
+
+    ret: Expected = inifix.load(DATA_DIR / "minimal.ini", return_type=Expected)
+
+    dum = ret["Dummy"]
+    dum["x"]
+    dum["y"].as_integer_ratio()
+
+
+def test_inconsistent_return_type() -> None:
+    # the way this test works is by relying on mypy's configuration details:
+    # unused 'type: ignore' comments are flagged, so the only way to pass here is if
+    # the 'assignment' error is actually raised
+    _ret: int = inifix.load(DATA_DIR / "minimal.ini", return_type=float)  # type: ignore[assignment]
+
+
+def test_incorrect_return_type() -> None:
+    # even specifying an incorrect return type should type-check
+    # (this is the responsibility of the user)
+    class Expected(TypedDict):
+        this_key_does_not_exist: int
+
+    ret: Expected = inifix.load(DATA_DIR / "idefix-khi.ini", return_type=Expected)
+
+    # ... but it should fail at runtime
+    with pytest.raises(KeyError):
+        ret["this_key_does_not_exist"]

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -18,7 +18,7 @@ INVADLID_SCHEMAS, INVALID_SCHEMAS_IDS = unzip(
 )
 
 
-@pytest.fixture(params=INVADLID_SCHEMAS, ids=INVALID_SCHEMAS_IDS)
+@pytest.fixture(params=INVADLID_SCHEMAS, ids=INVALID_SCHEMAS_IDS)  # type: ignore[call-overload]
 def invalid_conf(request):
     return request.param
 


### PR DESCRIPTION
This is in support to https://github.com/volodia99/nonos/pull/208, and needs to be validated downstream first