### PR TITLE
DEP: drop more-itertools as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,6 @@ classifiers = [
     "Typing :: Typed",
 ]
 requires-python = ">=3.9"
-dependencies = [
-    "more-itertools>=8.4",
-]
 dynamic = ["version"]
 
 [tool.setuptools.dynamic]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,3 @@
 coverage[toml]>=6.5
 pytest>=6.1
+more-itertools>=8.4

--- a/src/inifix/_more.py
+++ b/src/inifix/_more.py
@@ -1,0 +1,16 @@
+from collections.abc import Iterator
+from typing import Any
+
+
+def always_iterable(obj: Any, /) -> Iterator[Any]:
+    # adapated from more_iterools 10.1.0 (MIT)
+    if obj is None:
+        return iter(())
+
+    if isinstance(obj, str):
+        return iter((obj,))
+
+    try:
+        return iter(obj)
+    except TypeError:
+        return iter((obj,))

--- a/src/inifix/io.py
+++ b/src/inifix/io.py
@@ -7,8 +7,7 @@ from functools import partial
 from io import BufferedIOBase, IOBase
 from typing import Any, Callable, cast
 
-from more_itertools import always_iterable, mark_ends
-
+from inifix._more import always_iterable
 from inifix._typing import InifixConfT, IterableOrSingle, PathLike, Scalar, StrLike
 from inifix.enotation import ENotationIO
 from inifix.validation import SCALAR_TYPES, validate_inifile_schema
@@ -195,14 +194,15 @@ def _write_line(key: str, values: IterableOrSingle[Scalar], buffer: IOBase) -> N
 
 
 def _write_to_buffer(data: InifixConfT, buffer: IOBase) -> None:
-    for _is_first, is_last, (key, val) in mark_ends(data.items()):
+    last = len(data) - 1
+    for i, (key, val) in enumerate(data.items()):
         if not isinstance(val, dict):
             _write_line(key, val, buffer)
             continue
         _write(f"[{key}]\n", buffer)
         for k, v in val.items():
             _write_line(k, v, buffer)
-        if not is_last:
+        if i < last:
             _write("\n", buffer)
 
 

--- a/src/inifix/validation.py
+++ b/src/inifix/validation.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
-from more_itertools import always_iterable
+from inifix._more import always_iterable
 
 _PARAM_NAME_REGEXP = re.compile(r"[-\.\w]+")
 SCALAR_TYPES = (int, float, bool, str)


### PR DESCRIPTION
This is inifix's single dependency, and it's so little use that it seems worth going all in on zero-deps