### PR TITLE
RFC: refactor inifix-format in prep for threading parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - MNT: drop support for CPython 3.9
+- RFC: refactor `inifix-format` in preparation for multi-threading parallelism
 
 ## [4.5.0] - 2024-06-27
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -189,7 +189,7 @@ def test_data_preservation(inifile, tmp_path):
     assert round_mapping == initial_mapping
 
 
-N_FILES = 200
+N_FILES = 257
 
 
 @pytest.fixture


### PR DESCRIPTION
Keeping the actual multi-threading implementation out of this PR because I could not measure a performance gain yet and it actually seems slightly slower than the single-thread implementation at the moment (even on 3.13t).

For reference, my testing plan is
```
pytest tests/test_format.py::test_many_files --count 200
```
(requires `pytest-repeat`)