### PR TITLE
TST: ensure the GIL is disabled in free-threaded concurrency tests

### DIFF
--- a/.github/workflows/bleeding_edge.yml
+++ b/.github/workflows/bleeding_edge.yml
@@ -54,7 +54,18 @@ jobs:
       run: |
         source .venv/bin/activate
         pytest --color=yes --pyargs inifix --doctest-modules
-    - name: Run concurrency tests
+    - name: Run concurrency tests (GIL)
+      if: ${{ ! matrix.free-threading }}
       run: |
         source .venv/bin/activate
         pytest --color=yes --count 100 tests/test_concurrent.py
+    - name: Run concurrency tests (free-threading)
+      if: matrix.free-threading
+      run: |
+        source .venv/bin/activate
+        pytest --color=yes --count 100 tests/test_concurrent.py
+      # it *should* be possible to enforce GIL disabling with PYTHON_GIL
+      # but the deadsnake binary seems broken and chokes on it
+      # (last checked 2024-10-12)
+      #env:
+      #  PYTHON_GIL: 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pytest
@@ -15,3 +16,14 @@ def datadir():
 @pytest.fixture(params=INIFILES, ids=INIFILES_IDS)
 def inifile(request):
     return request.param
+
+
+def pytest_report_header(config, start_path):
+    if sys.version_info >= (3, 13):
+        is_gil_enabled = sys._is_gil_enabled()
+    else:
+        is_gil_enabled = True
+
+    return [
+        f"{is_gil_enabled = }",
+    ]


### PR DESCRIPTION
~~Based off #266~~
for some reason I can't understand right now, this doesn't work out of the box. I'll come back to this.