### PR TITLE
RFC: flatten logic tree

### DIFF
--- a/src/inifix/_cli.py
+++ b/src/inifix/_cli.py
@@ -21,11 +21,10 @@ def get_cpu_count() -> int:
     base_cpu_count: int | None
     if sys.version_info >= (3, 13):
         base_cpu_count = os.process_cpu_count()
-    else:
-        if hasattr(os, "sched_getaffinity"):
-            # this function isn't available on all platforms
-            base_cpu_count = len(os.sched_getaffinity(0))
-        else:  # pragma: no cover
-            # this proxy is good enough in most situations
-            base_cpu_count = os.cpu_count()
+    elif hasattr(os, "sched_getaffinity"):
+        # this function isn't available on all platforms
+        base_cpu_count = len(os.sched_getaffinity(0))
+    else:  # pragma: no cover
+        # this proxy is good enough in most situations
+        base_cpu_count = os.cpu_count()
     return base_cpu_count or 1


### PR DESCRIPTION
I think my initial motivation for using a nested if/else structure was to allow `ruff check --fix --unsafe-fixes --select UP036` to clean the logic up, but it turns out it also knows how to fix the more natural structure.