### PR TITLE
PERF: delay most costly import statements until they are needed

### DIFF
--- a/src/inifix/__init__.py
+++ b/src/inifix/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .io import dump
 from .io import dumps
 from .io import load
@@ -5,7 +7,18 @@ from .io import loads
 from .validation import validate_inifile_schema
 from .format import format_string
 
-from importlib.metadata import version
+from typing import TYPE_CHECKING
 
-__version__ = version("inifix")
-del version
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    if name == "__version__":
+        from importlib.metadata import version
+
+        return version("inifix")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+del TYPE_CHECKING

--- a/src/inifix/format.py
+++ b/src/inifix/format.py
@@ -1,14 +1,11 @@
-import argparse
 import os
 import re
 import sys
 import warnings
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor
 from difflib import unified_diff
 from functools import partial
 from io import StringIO
-from tempfile import TemporaryDirectory
 from typing import IO, Literal
 
 from inifix._cli import Message, TaskResults, get_cpu_count
@@ -141,7 +138,10 @@ def iniformat(s: str, /) -> str:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser()
+    from argparse import ArgumentParser
+    from concurrent.futures import ThreadPoolExecutor
+
+    parser = ArgumentParser()
     parser.add_argument("files", nargs="+")
     parser.add_argument(
         "--diff",
@@ -231,6 +231,8 @@ def _format_single_file_cli(
                 )
             )
             return TaskResults(status, messages)
+
+        from tempfile import TemporaryDirectory
 
         with TemporaryDirectory(dir=os.path.dirname(file)) as tmpdir:
             tmpfile = os.path.join(tmpdir, "ini")

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,14 @@
+from importlib.metadata import version
+
+import pytest
+
+import inifix
+
+
+def test_dunder_version():
+    assert inifix.__version__ == version("inifix")
+
+
+def test_unknown_member():
+    with pytest.raises(AttributeError):
+        inifix.unknown_member  # noqa: B018


### PR DESCRIPTION
This shaves about 60% off of import time on my x86 laptop