### PR TITLE
TYP: fix a warning reported by pyright

### DIFF
--- a/src/inifix/__init__.py
+++ b/src/inifix/__init__.py
@@ -22,6 +22,8 @@ __all__ = [
     "__version__",
 ]
 
+__version__: str
+
 
 def __getattr__(name: str) -> Any:
     if name == "__version__":
@@ -29,6 +31,3 @@ def __getattr__(name: str) -> Any:
 
         return version("inifix")
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-del TYPE_CHECKING


### PR DESCRIPTION
Further address #298
fix the following warning:

```
/Users/clm/dev/inifix/src/inifix/__init__.py
  /Users/clm/dev/inifix/src/inifix/__init__.py:22:5 - warning: "__version__" is specified in __all__ but is not present in module (reportUnsupportedDunderAll)
```