### PR TITLE
ENH: add sections-mode selection to `inifix.validate_inifile_schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TYP: add missing `__all__` symbol to inifix's root namespace
 - TYP: fix errors reported by `pyright`
 - ENH: add `inifix.__version_tuple__`
+- ENH: add sections-mode selection to `inifix.validate_inifile_schema`
 
 ## [5.0.4] - 2024-11-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 requires-python = ">=3.10"
+dependencies = [
+    "typing-extensions>=4.1.0 ; python_full_version < '3.11'",
+]
 
 [project.license]
 text = "GPL-3.0"

--- a/src/inifix/validation.py
+++ b/src/inifix/validation.py
@@ -1,11 +1,24 @@
 import re
+import sys
 from collections.abc import Mapping
-from typing import Any
+from enum import Enum, auto
+from typing import Any, Literal
 
 from inifix._more import always_iterable
 
+if sys.version_info >= (3, 11):
+    from typing import assert_never
+else:
+    from typing_extensions import assert_never
+
 _PARAM_NAME_REGEXP = re.compile(r"[-\.\w]+")
 SCALAR_TYPES = (int, float, bool, str)
+
+
+class SectionsMode(Enum):
+    ALLOW = auto()
+    FORBID = auto()
+    REQUIRE = auto()
 
 
 def _uses_invalid_chars(s: str) -> bool:
@@ -44,19 +57,75 @@ def validate_elementary_item(key: Any, value: Any) -> None:
             )
 
 
-def validate_inifile_schema(d: Mapping, /) -> None:
+def validate_inifile_schema(
+    data: Mapping,
+    /,
+    *,
+    sections: Literal["allow", "forbid", "require"] = "allow",
+) -> None:
     """
-    Raise `ValueError` if and only if the argument is not a
-    valid configuration.
-    """
+    Validate structure of a dictionary as an inifix-compliant configuration.
 
-    for k, v in d.items():
+    Parameters
+    ----------
+    data: dict
+      the candidate configuration to be (in)validated.
+
+    sections: 'allow', 'forbid' or 'require' (default: 'allow')
+      use sections='forbid' to invalidate any section found,
+      or sections='require' to invalidate a sectionless structure.
+      Default mode (sections='allow') permits both.
+
+      .. versionadded: 5.1.0
+
+    Raises
+    ------
+    TypeError: for unrecognized values in parameter sections.
+    ValueError: if and only if data does not conform to the expected schema.
+
+    """
+    match sections:
+        case "allow":
+            sections_mode = SectionsMode.ALLOW
+        case "forbid":
+            sections_mode = SectionsMode.FORBID
+        case "require":
+            sections_mode = SectionsMode.REQUIRE
+        case _:
+            raise TypeError(
+                "Unknown value for parameter sections. "
+                f"Got {sections=!r}, expected 'allow', 'forbid' or 'require'"
+            )
+
+    for k, v in data.items():
         if not isinstance(k, str):
             raise ValueError(
-                f"Invalid schema: received key '{k}' with type '{type(k)}', expected a str"
+                f"Invalid schema: received key '{k}' "
+                f"with type '{type(k)}', expected a str"
             )
+
         if isinstance(v, dict):
-            for kk, vv in v.items():
-                validate_elementary_item(kk, vv)
+            match sections_mode:
+                case SectionsMode.ALLOW | SectionsMode.REQUIRE:
+                    for kk, vv in v.items():
+                        validate_elementary_item(kk, vv)
+                case SectionsMode.FORBID:
+                    raise ValueError(
+                        "Invalid schema: sections were explicitly forbidden, "
+                        f"but one was found under key '{k}'"
+                    )
+                case _:  # pragma: no cover
+                    assert_never(sections_mode)
+
         else:
-            validate_elementary_item(k, v)
+            match sections_mode:
+                case SectionsMode.ALLOW | SectionsMode.FORBID:
+                    validate_elementary_item(k, v)
+                case SectionsMode.REQUIRE:
+                    raise ValueError(
+                        "Invalid schema: sections were explicitly required, "
+                        "but the following key/value pair was found outside of "
+                        f"any section: '{k}', {v}"
+                    )
+                case _:  # pragma: no cover
+                    assert_never(sections_mode)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,19 @@ from pathlib import Path
 import pytest
 
 DATA_DIR = Path(__file__).parent / "data"
-INIFILES = list(DATA_DIR.glob("*.ini")) + list(DATA_DIR.glob("*.cfg"))
-INIFILES_IDS = [inifile.name[:-4] for inifile in INIFILES]
+INIFILES_PATHS = list(DATA_DIR.glob("*.ini")) + list(DATA_DIR.glob("*.cfg"))
+INIFILES_IDS = [inifile.name[:-4] for inifile in INIFILES_PATHS]
+
+INIFILES = dict(zip(INIFILES_PATHS, INIFILES_IDS, strict=True))
+
+INIFILES_WO_SECTIONS = {
+    path: id
+    for path, id in INIFILES.items()
+    if "fargo" not in id and path.suffix != ".cfg"
+}
+INIFILES_W_SECTIONS = {
+    path: id for path, id in INIFILES.items() if path not in INIFILES_WO_SECTIONS
+}
 
 
 @pytest.fixture()
@@ -13,8 +24,18 @@ def datadir():
     return DATA_DIR
 
 
-@pytest.fixture(params=INIFILES, ids=INIFILES_IDS)
+@pytest.fixture(params=INIFILES.keys(), ids=INIFILES.values())
 def inifile(request):
+    return request.param
+
+
+@pytest.fixture(params=INIFILES_W_SECTIONS.keys(), ids=INIFILES_W_SECTIONS.values())
+def inifile_with_sections(request):
+    return request.param
+
+
+@pytest.fixture(params=INIFILES_WO_SECTIONS.keys(), ids=INIFILES_WO_SECTIONS.values())
+def inifile_without_sections(request):
     return request.param
 
 

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -6,7 +6,38 @@ from inifix.validation import validate_inifile_schema
 
 def test_validate_known_files(inifile):
     conf = load(inifile)
+    # implicit form
     validate_inifile_schema(conf)
+
+    # explicit form
+    validate_inifile_schema(conf, sections="allow")
+
+
+def test_validate_known_files_with_sections(inifile_with_sections):
+    conf = load(inifile_with_sections)
+    validate_inifile_schema(conf, sections="forbid")
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Invalid schema: sections were explicitly required, "
+            "but the following key/value pair was found outside of "
+            "any section"
+        ),
+    ):
+        validate_inifile_schema(conf, sections="require")
+
+
+def test_validate_known_files_without_sections(inifile_without_sections):
+    conf = load(inifile_without_sections)
+    validate_inifile_schema(conf, sections="require")
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Invalid schema: sections were explicitly forbidden, "
+            "but one was found under key"
+        ),
+    ):
+        validate_inifile_schema(conf, sections="forbid")
 
 
 @pytest.mark.parametrize(
@@ -29,3 +60,8 @@ def test_validate_known_files(inifile):
 def test_dump_invalid_conf(invalid_conf, tmp_path):
     with pytest.raises(ValueError, match=r"^(Invalid schema)"):
         dump(invalid_conf, tmp_path / "save.ini")
+
+
+def test_unknown_sections_value():
+    with pytest.raises(TypeError):
+        validate_inifile_schema({}, sections="unknown-value")

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,9 @@ wheels = [
 name = "inifix"
 version = "5.0.4"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
 
 [package.dev-dependencies]
 concurrency = [
@@ -145,6 +148,7 @@ typecheck = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.1.0" }]
 
 [package.metadata.requires-dev]
 concurrency = [


### PR DESCRIPTION
Lay the fundations for an idea that came out of #301
Supporting this option in `load(s)` and `dump(s)` will be done in a follow up PR

TODO: 
- [x] pass CI
- [ ] add documentation (update: postponed to #309) 