### PR TITLE
DOC: avoid duplicated docstring sources using string interpolation

### DIFF
--- a/src/inifix/validation.py
+++ b/src/inifix/validation.py
@@ -71,7 +71,7 @@ def validate_inifile_schema(
     data: dict
       the candidate configuration to be (in)validated.
 
-    sections: 'allow', 'forbid' or 'require' (default: 'allow')
+    sections: 'allow' (default), 'forbid' or 'require'
       use sections='forbid' to invalidate any section found,
       or sections='require' to invalidate a sectionless structure.
       Default mode (sections='allow') permits both.


### PR DESCRIPTION
I also improved consistency and internal references in the affected paragraphs.