### PR TITLE
TYP: ensure type annotations of the IO API are accessible at runtime in Python 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-TYP: prefer absolute forward references and avoid `__future__.annotations`
+- TYP: prefer absolute forward references and avoid `__future__.annotations`
+- TYP: ensure type annotations of the IO API are accessible at runtime in Python 3.14
 
 ## [5.1.2] - 2024-12-16
 

--- a/src/inifix/io.py
+++ b/src/inifix/io.py
@@ -1,9 +1,9 @@
 import os
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from functools import partial
 from io import BufferedIOBase, IOBase
-from typing import TYPE_CHECKING, Any, Literal, cast, overload
+from typing import Any, Literal, cast, overload
 
 from inifix._more import always_iterable
 from inifix._typing import (
@@ -18,11 +18,6 @@ from inifix._typing import (
 )
 from inifix.enotation import ENotationIO
 from inifix.validation import SCALAR_TYPES, validate_inifile_schema
-
-if TYPE_CHECKING:  # pragma: no cover
-    import collections.abc
-
-    import _typeshed
 
 __all__ = [
     "dump",
@@ -46,7 +41,7 @@ def _is_numeric(s: str) -> bool:
 class Section(dict[str, Any]):
     def __init__(
         self,
-        data: "Mapping[str, collections.abc.Iterable[Scalar] | Scalar] | None" = None,
+        data: Mapping[str, Iterable[Scalar] | Scalar] | None = None,
         /,
         *,
         name: str | None = None,
@@ -241,7 +236,7 @@ def _from_file_descriptor(
 
 
 def _from_path(
-    file: "_typeshed.GenericPath[str]",
+    file: str | os.PathLike[str],
     *,
     parse_scalars_as_lists: bool,
     caster: CasterFunction,
@@ -279,9 +274,7 @@ def _write(content: str, buffer: IOBase) -> None:
         buffer.write(content)
 
 
-def _write_line(
-    key: str, values: "collections.abc.Iterable[Scalar] | Scalar", buffer: IOBase
-) -> None:
+def _write_line(key: str, values: Iterable[Scalar] | Scalar, buffer: IOBase) -> None:
     val_repr = [_encode(v) for v in always_iterable(values)]
     _write(f"{key} {'  '.join(list(val_repr))}\n", buffer)
 
@@ -299,7 +292,7 @@ def _write_to_buffer(data: AnyConfig, buffer: IOBase) -> None:
             _write("\n", buffer)
 
 
-def _write_to_file(data: AnyConfig, file: "_typeshed.GenericPath[str]", /) -> None:
+def _write_to_file(data: AnyConfig, file: str | os.PathLike[str], /) -> None:
     if os.path.exists(file) and not os.access(file, os.W_OK):
         raise PermissionError(f"Cannot write to {file} (permission denied)")
 
@@ -329,7 +322,7 @@ def _write_to_file(data: AnyConfig, file: "_typeshed.GenericPath[str]", /) -> No
 
 @overload
 def load(
-    source: "_typeshed.GenericPath[str] | IOBase",
+    source: str | os.PathLike[str] | IOBase,
     /,
     *,
     sections: Literal["forbid"],
@@ -339,7 +332,7 @@ def load(
 ) -> Config_SectionsForbidden_ScalarsForbidden: ...
 @overload
 def load(
-    source: "_typeshed.GenericPath[str] | IOBase",
+    source: str | os.PathLike[str] | IOBase,
     /,
     *,
     sections: Literal["require"],
@@ -349,7 +342,7 @@ def load(
 ) -> Config_SectionsRequired_ScalarsForbidden: ...
 @overload
 def load(
-    source: "_typeshed.GenericPath[str] | IOBase",
+    source: str | os.PathLike[str] | IOBase,
     /,
     *,
     sections: Literal["forbid"],
@@ -359,7 +352,7 @@ def load(
 ) -> Config_SectionsForbidden_ScalarsAllowed: ...
 @overload
 def load(
-    source: "_typeshed.GenericPath[str] | IOBase",
+    source: str | os.PathLike[str] | IOBase,
     /,
     *,
     sections: Literal["require"],
@@ -369,7 +362,7 @@ def load(
 ) -> Config_SectionsRequired_ScalarsAllowed: ...
 @overload
 def load(
-    source: "_typeshed.GenericPath[str] | IOBase",
+    source: str | os.PathLike[str] | IOBase,
     /,
     *,
     parse_scalars_as_lists: Literal[True],
@@ -379,7 +372,7 @@ def load(
 ) -> Config_SectionsAllowed_ScalarsForbidden: ...
 @overload
 def load(
-    source: "_typeshed.GenericPath[str] | IOBase",
+    source: str | os.PathLike[str] | IOBase,
     /,
     *,
     parse_scalars_as_lists: Literal[False] = False,
@@ -390,7 +383,7 @@ def load(
 
 
 def load(
-    source: "_typeshed.GenericPath[str] | IOBase",
+    source: str | os.PathLike[str] | IOBase,
     /,
     *,
     # parsing options
@@ -604,7 +597,7 @@ def loads(
 def dump(
     data: AnyConfig,
     /,
-    file: "_typeshed.GenericPath[str] | IOBase",
+    file: str | os.PathLike[str] | IOBase,
     *,
     # validation options
     sections: Literal["allow", "forbid", "require"] = "allow",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import difflib
 import os
 import re
+import sys
 import tempfile
 from io import BytesIO
 from pathlib import Path
@@ -368,3 +369,18 @@ def test_unknown_integer_casting():
         match="Unknown integer_casting value 'unknown_strategy'.",
     ):
         loads(input_data, integer_casting="unknown_strategy")
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="annotationlib is new in Python 3.14",
+)
+@pytest.mark.parametrize("func", [load, loads, dump, dumps])
+@pytest.mark.parametrize("format", ["VALUE", "FORWARDREF", "STRING"])
+def test_runtime_annotations(func, format):  # pragma: no cover
+    from annotationlib import Format, get_annotations
+
+    # check that no exception is raised
+    # this test *may* be refined once Python 3.14 is out of beta
+    get_annotations(func, format=getattr(Format, format))
+    get_annotations(func, eval_str=True)


### PR DESCRIPTION
- **TST: test runtime type annotation parsing in Python 3.14**
- **TYP: ensure type annotations of the IO API are accessible at runtime in Python 3.14**
