### PR TITLE
TYP: improve some excessively vague (or missing) type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ exclude_lines = [
     "-> ['\"]?NoReturn['\"]?:",
 ]
 
+[tool.pyright]
+reportImplicitStringConcatenation = false
+
 [tool.mypy]
 python_version = "3.10"
 show_error_codes = true

--- a/src/inifix/_more.py
+++ b/src/inifix/_more.py
@@ -1,13 +1,14 @@
 from collections.abc import Iterator
-from typing import Any
+
+from inifix._typing import Scalar
 
 
-def always_iterable(obj: Any, /) -> Iterator[Any]:
+def always_iterable(obj: Scalar | list[Scalar], /) -> Iterator[Scalar]:
     # adapted from more_iterools 10.1.0 (MIT)
     if isinstance(obj, str):
         return iter((obj,))
 
-    try:
+    if isinstance(obj, list):
         return iter(obj)
-    except TypeError:
+    else:
         return iter((obj,))

--- a/src/inifix/format.py
+++ b/src/inifix/format.py
@@ -21,10 +21,10 @@ PADDING_SIZE = 2
 
 def _format_section(data: str) -> str:
     lines = data.splitlines()
-    contents = []
-    comments = []
-    parameters = []
-    values = []
+    contents: list[str] = []
+    comments: list[str] = []
+    parameters: list[str] = []
+    values: list[list[str]] = []
     for line in lines:
         content, _, comment = line.partition("#")
         content = content.strip()
@@ -57,7 +57,7 @@ def _format_section(data: str) -> str:
     padded_name_col_size = max_name_size + 2 * PADDING_SIZE
     content_size = padded_name_col_size + sum(column_sizes) + PADDING_SIZE
 
-    new_lines = []
+    new_lines: list[str] = []
     parameter_idx = 0
     for content, comment in zip(contents, comments, strict=True):
         new_line = ""
@@ -123,7 +123,7 @@ def format_string(s: str, /) -> str:
     <BLANKLINE>
     """
     fh = StringIO(s)
-    content = []
+    content: list[str] = []
     for s in _iter_sections(fh):
         content.append(_format_section(s))
     return _finalize("\n".join(content))

--- a/src/inifix/io.py
+++ b/src/inifix/io.py
@@ -109,7 +109,7 @@ TRUTHY_STRINGS = frozenset({"true", "TRUE", "True", "yes", "YES", "Yes"})
 FALSY_STRINGS = frozenset({"false", "FALSE", "False", "no", "NO", "No"})
 ALL_BOOL_STRINGS = frozenset({*TRUTHY_STRINGS, *FALSY_STRINGS})
 
-_RE_CASTERS: list[tuple[re.Pattern, Callable[[str], Any]]] = [
+_RE_CASTERS: list[tuple[re.Pattern[str], Callable[[str], Scalar]]] = [
     (re.compile("(" + "|".join(TRUTHY_STRINGS) + ")"), lambda _: True),
     (re.compile("(" + "|".join(FALSY_STRINGS) + ")"), lambda _: False),
     (re.compile(r"^'.*'$"), lambda s: s[1:-1]),
@@ -274,7 +274,7 @@ def _write(content: str, buffer: IOBase) -> None:
         buffer.write(content)
 
 
-def _write_line(key: str, values: Iterable[Scalar] | Scalar, buffer: IOBase) -> None:
+def _write_line(key: str, values: Scalar | list[Scalar], buffer: IOBase) -> None:
     val_repr = [_encode(v) for v in always_iterable(values)]
     _write(f"{key} {'  '.join(list(val_repr))}\n", buffer)
 


### PR DESCRIPTION
This fixes a couple minor issues I found running `basedpyright` with default configuration (which is stricter than pyright's). I'm not going to fix all errors flaged by this stricter typechecker because I found two areas where it (likely) is impossible to satisfy it:
- public functions that are meant to accept user inputs may contain some paths that are, when used correctly, unreachable, but we don't want to flag them as such, as they are still valuable for runtime validation.
- `argparse` doesn't seem to be annotated so anything that uses it if effectively full of `Any` as far as the typechecker is concerned. This is not something I can fix on my side in the general case.
