### PR TITLE
RFC: prefer dataclasses to named tuples

### DIFF
--- a/src/inifix/_cli.py
+++ b/src/inifix/_cli.py
@@ -1,14 +1,17 @@
 import os
 import sys
-from typing import Literal, NamedTuple, TextIO
+from dataclasses import dataclass
+from typing import Literal, TextIO
 
 
-class Message(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class Message:
     content: str
     dest: TextIO
 
 
-class TaskResults(NamedTuple):
+@dataclass(frozen=True, slots=True)
+class TaskResults:
     status: Literal[0, 1]
     messages: list[Message]
 


### PR DESCRIPTION
rationale: named tuples are tuples, and as such, support a range of operations I don't intend to get here, e.g., unpacking.