### PR TITLE
TYP: reconfigure mypy (enable strict mode)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,12 +130,9 @@ reportUnnecessaryComparison = false
 
 [tool.mypy]
 python_version = "3.10"
+strict = true
 show_error_codes = true
-warn_unused_configs = true
-warn_unused_ignores = true
-warn_unreachable = true
 show_error_context = true
-disallow_untyped_defs = true
 
 [[tool.mypy.overrides]]
 module = "tests.*"


### PR DESCRIPTION
Enabling strict mode is currently free (it already type checks !), so let's do it now before new errors creep in.