### PR TITLE
RFC: move CLI's logic to `__main__` module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,13 +67,13 @@ known-first-party = ["inifix"]
 [tool.coverage.run]
 branch = true
 source = [
-    "src",
+    "src/__init__.py",
     "tests",
     "lib/inifix/src",
     "lib/inifix/tests",
 ]
 omit = [
-  "scripts/*",
+    "scripts/*",
 ]
 
 [tool.coverage.report]

--- a/src/inifix_cli/__init__.py
+++ b/src/inifix_cli/__init__.py
@@ -4,13 +4,17 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from difflib import unified_diff
 from functools import partial
-from typing import TYPE_CHECKING, Annotated, Literal, TextIO, NewType
+from typing import TYPE_CHECKING, Annotated, Literal, NewType
+
 import typer
 
 import inifix
 
 if TYPE_CHECKING:  # pragma: no cover
     from inifix._typing import AnyConfig
+
+
+__all__ = ["app"]
 
 app: typer.Typer = typer.Typer()
 
@@ -186,7 +190,3 @@ def _format_single_file(
             os.replace(tmpfile, file)
 
     return TaskResults(status, messages)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    app()

--- a/src/inifix_cli/__main__.py
+++ b/src/inifix_cli/__main__.py
@@ -1,0 +1,4 @@
+from inifix_cli import app
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
This enables `uv run -m idefix_cli` for testing convenience.