### PR TITLE
RFC: rewrite enotation module

### DIFF
--- a/.github/workflows/bleeding_edge.yml
+++ b/.github/workflows/bleeding_edge.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Run tests
       run: |
         uv run --no-sync \
-          pytest --color=yes --doctest-modules
+          pytest --color=yes
 
     - run: uv sync --frozen --no-editable --group concurrency
     - name: Run concurrency tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,13 @@ jobs:
       shell: bash  # for windows portability
       run: |
         uv run --frozen --no-editable --group test \
-          pytest --color=yes --doctest-modules
+          pytest --color=yes
 
     - name: Run tests (with coverage)
       if: ${{ startswith( matrix.os, 'ubuntu' ) }}
       run: |
-        uv run --no-editable --group covcheck \
-          coverage run --parallel-mode -m pytest --color=yes --doctest-modules
+        uv run --group covcheck \
+          coverage run --parallel-mode -m pytest --color=yes
 
     - name: Upload coverage data
       # only using reports from ubuntu because
@@ -167,7 +167,7 @@ jobs:
     - name: Run pytest with PYTHONOPTIMIZE=2
       run: |
         uv run --frozen --no-editable --group test \
-          pytest --color=yes --doctest-modules
+          pytest --color=yes
       env:
         PYTHONOPTIMIZE: 2
 

--- a/conftest.py
+++ b/conftest.py
@@ -19,11 +19,6 @@ INIFILES_WO_SECTIONS = {
 }
 
 
-def pytest_ignore_collect(collection_path: Path):
-    if "scripts" in str(collection_path):
-        return True
-
-
 @pytest.fixture()
 def datadir():
     return DATA_DIR

--- a/lib/inifix/src/inifix/_enotation.py
+++ b/lib/inifix/src/inifix/_enotation.py
@@ -1,98 +1,31 @@
 import re
+import sys
+from enum import Enum, auto
+
+if sys.version_info >= (3, 11):
+    from typing import assert_never
+else:
+    from typing_extensions import assert_never
+
+__all__ = ["Enotation"]
 
 ENOTATION_REGEXP = re.compile(r"\d+(\.\d*)?e[+-]?\d+?")
 
 
-class ENotationIO:
-    """A small class to encode/decode real numbers to and from
-    e-notation formatted strings.
-
-    """
+class Enotation(Enum):
+    ALWAYS = auto()
+    ONLY_SHORTER = auto()
 
     @staticmethod
-    def decode(s: str, /) -> int:
-        """
-        Cast an 'e' formatted string `s` to integer if such a conversion can
-        be performed without loss of data. Raise ValueError otherwise.
-
-        Examples
-        --------
-        >>> ENotationIO.decode("6.28E2")
-        628
-        >>> ENotationIO.decode("1.4e3")
-        1400
-        >>> ENotationIO.decode("7.0000E2")
-        700
-        >>> ENotationIO.decode("700.00E-2")
-        7
-        >>> ENotationIO.decode("700e-2")
-        7
-        >>> ENotationIO.decode("6.000e0")
-        6
-        >>> ENotationIO.decode("700e-3")
-        Traceback (most recent call last):
-        ...
-        ValueError
-        >>> ENotationIO.decode("7.0001E2")
-        Traceback (most recent call last):
-        ...
-        ValueError
-        >>> ENotationIO.decode("0.6e0")
-        Traceback (most recent call last):
-        ...
-        ValueError
-        >>> ENotationIO.decode("notanumber")
-        Traceback (most recent call last):
-        ...
-        ValueError
-        """
-        s = s.lower()
-
-        if not re.match(ENOTATION_REGEXP, s):
-            raise ValueError
-
-        digits, _, sexponent = s.partition("e")
-        exponent = int(sexponent)
-        if "." in digits:
-            digits, decimals = digits.split(".")
-            decimals = decimals.rstrip("0")
-        else:
-            decimals = ""
-
-        if exponent >= 0 and len(decimals) > exponent:
-            raise ValueError
-        elif exponent < 0 and len(digits) - 1 < -exponent:
-            raise ValueError
-
-        return int(float(s))
-
-    @staticmethod
-    def simplify(s: str, /) -> str:
+    def _simplify(s: str, /) -> str:
         """
         Simplify exponents and trailing zeros in decimals.
-        This is a helper function to `ENotationIO.encode`.
-
-        >>> ENotationIO.simplify('1e-00')
-        '1e0'
-        >>> ENotationIO.simplify('1e+00')
-        '1e0'
-        >>> ENotationIO.simplify('1e-01')
-        '1e-1'
-        >>> ENotationIO.simplify('1e+01')
-        '1e1'
-        >>> ENotationIO.simplify('1e+10')
-        '1e10'
-        >>> ENotationIO.simplify('1.000e+00')
-        '1e0'
-        >>> ENotationIO.simplify('1.100e+00')
-        '1.1e0'
         """
         s = re.sub(r"\.?0*(e[+-]?)0", r"\1", s)
         s = re.sub(r"(e-0)$", "e0", s)
         return s.replace("+", "")
 
-    @staticmethod
-    def encode(r: float, /) -> str:
+    def _encode_unconditionally(self, r: float, /) -> str:
         """
         Convert a real number `r` to string, using scientific notation.
 
@@ -107,56 +40,23 @@ class ENotationIO:
         Returns
         -------
         ret: str
-            A string representing a number in sci notation
+            A string representing r in sci notation
 
-        Examples
-        --------
-        >>> ENotationIO.encode(1)
-        '1e0'
-        >>> ENotationIO.encode(0.0000001)
-        '1e-7'
-        >>> ENotationIO.encode(10_000_000)
-        '1e7'
-        >>> ENotationIO.encode(156_000)
-        '1.56e5'
-        >>> ENotationIO.encode(0.0056)
-        '5.6e-3'
-        >>> ENotationIO.encode(3.141592653589793)
-        '3.141592653589793e0'
-        >>> ENotationIO.encode(1e-15)
-        '1e-15'
-        >>> ENotationIO.encode(0.0)
-        '0e0'
-        >>> ENotationIO.encode(0)
-        '0e0'
         """
         base = str(r)
         if "e" in base:
-            return ENotationIO.simplify(base)
+            return self._simplify(base)
         if not base.strip(".0"):
             return "0e0"
         max_ndigit = len(base.replace(".", "")) - 1
-        return ENotationIO.simplify(f"{r:.{max_ndigit}e}")
+        return self._simplify(f"{r:.{max_ndigit}e}")
 
-    @staticmethod
-    def encode_preferential(r: float, /) -> str:
-        """
-        Convert a float `r` to string, using sci notation if
-        and only if it saves space.
-
-        Examples
-        --------
-        >>> ENotationIO.encode_preferential(189_000_000)
-        '1.89e8'
-        >>> ENotationIO.encode_preferential(189)
-        '189.0'
-        >>> ENotationIO.encode_preferential(900)
-        '9e2'
-        >>> ENotationIO.encode_preferential(1)
-        '1.0'
-        >>> ENotationIO.encode_preferential(0.7)
-        '0.7'
-        >>> ENotationIO.encode_preferential(0.00007)
-        '7e-5'
-        """
-        return min(str(float(r)), ENotationIO.encode(r), key=lambda x: len(x))
+    def encode(self, r: float, /) -> str:
+        result = self._encode_unconditionally(r)
+        match self:
+            case Enotation.ALWAYS:
+                return result
+            case Enotation.ONLY_SHORTER:
+                return min(str(float(r)), result, key=lambda x: len(x))
+            case _:  # pragma: no cover
+                assert_never(self)

--- a/lib/inifix/src/inifix/_io.py
+++ b/lib/inifix/src/inifix/_io.py
@@ -6,7 +6,7 @@ from io import BufferedIOBase, IOBase
 from itertools import pairwise
 from typing import Literal, Protocol, overload
 
-from inifix._enotation import ENotationIO
+from inifix._enotation import Enotation
 from inifix._typing import (
     AnyConfig,
     Config_SectionsAllowed_ScalarsForbidden,
@@ -304,7 +304,7 @@ def _from_path(
 
 def _encode(v: Scalar) -> str:
     if isinstance(v, float):
-        return ENotationIO.encode_preferential(v)
+        return Enotation.ONLY_SHORTER.encode(v)
     elif isinstance(v, str) and (
         v == ""
         or re.search(r"\s", v) is not None

--- a/lib/inifix/tests/test_casting.py
+++ b/lib/inifix/tests/test_casting.py
@@ -5,7 +5,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 import inifix
-from inifix._enotation import ENotationIO
+from inifix._enotation import Enotation
 from inifix._io import _auto_cast_aggressive, _auto_cast_stable
 
 BASE_BOOLS = [
@@ -67,7 +67,7 @@ def test_unambiguous_int_cast_aggressive(i):
 @given(st.integers())
 def test_int_like_floats_casting(caster, expected_type, i):
     f = float(i)
-    for s in (str(f), ENotationIO.encode(i)):
+    for s in (str(f), Enotation.ALWAYS.encode(i)):
         res = caster(s)
         assert res == f
         assert type(res) is expected_type

--- a/lib/inifix/tests/test_enotation.py
+++ b/lib/inifix/tests/test_enotation.py
@@ -1,0 +1,54 @@
+import pytest
+
+from inifix._enotation import Enotation
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        ("1e-00", "1e0"),
+        ("1e-01", "1e-1"),
+        ("1e+01", "1e1"),
+        ("1e+10", "1e10"),
+        ("1.000e+00", "1e0"),
+        ("1.100e+00", "1.1e0"),
+    ],
+)
+def test_simplify(input, expected):
+    assert Enotation._simplify(input) == expected
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (1, "1e0"),
+        (0.000_000_1, "1e-7"),
+        (10_000_000, "1e7"),
+        (156_000, "1.56e5"),
+        (0.0056, "5.6e-3"),
+        (3.141592653589793, "3.141592653589793e0"),
+        (1e-15, "1e-15"),
+        (0.0, "0e0"),
+        (0, "0e0"),
+    ],
+)
+def test_always_encode(input, expected):
+    assert Enotation.ALWAYS.encode(input) == expected
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (1, "1.0"),
+        (0.000_000_1, "1e-7"),
+        (10_000_000, "1e7"),
+        (156_000, "1.56e5"),
+        (0.0056, "0.0056"),
+        (3.141592653589793, "3.141592653589793"),
+        (1e-15, "1e-15"),
+        (0.0, "0.0"),
+        (0, "0.0"),
+    ],
+)
+def test_only_shorter_encode(input, expected):
+    assert Enotation.ONLY_SHORTER.encode(input) == expected


### PR DESCRIPTION
Now that the module is marked as private I can rewrite it to my current taste and style.
TODO:
- [x] import a single item
- [x] convert doctests to regular tests
- [x] cleanup doctest-related cruft (CLI flags in CI, conftest.py ...)