### PR TITLE
BLD: ensure conftest.py is included in source distributions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
     - name: Build distributions
       shell: bash -l {0}
-      run: uv build lib/inifix
+      run: uv build --package inifix
 
     - name: Publish package distributions to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/lib/inifix/tests/conftest.py
+++ b/lib/inifix/tests/conftest.py
@@ -1,9 +1,8 @@
-import sys
 from pathlib import Path
 
 import pytest
 
-DATA_DIR = Path(__file__).parent / "lib" / "inifix" / "tests" / "data"
+DATA_DIR = Path(__file__).parent / "data"
 INIFILES_PATHS = list(DATA_DIR.glob("*.ini")) + list(DATA_DIR.glob("*.cfg"))
 INIFILES_IDS = [inifile.name[:-4] for inifile in INIFILES_PATHS]
 
@@ -37,14 +36,3 @@ def inifile_with_sections(request):
 @pytest.fixture(params=INIFILES_WO_SECTIONS.keys(), ids=INIFILES_WO_SECTIONS.values())
 def inifile_without_sections(request):
     return request.param
-
-
-def pytest_report_header(config, start_path):
-    if sys.version_info >= (3, 13):
-        is_gil_enabled = sys._is_gil_enabled()
-    else:
-        is_gil_enabled = True
-
-    return [
-        f"{is_gil_enabled = }",
-    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+DATA_DIR = Path(__file__).parents[1] / "lib" / "inifix" / "tests" / "data"
+INIFILES_PATHS = list(DATA_DIR.glob("*.ini")) + list(DATA_DIR.glob("*.cfg"))
+INIFILES_IDS = [inifile.name[:-4] for inifile in INIFILES_PATHS]
+
+INIFILES = dict(zip(INIFILES_PATHS, INIFILES_IDS, strict=True))
+
+
+@pytest.fixture()
+def datadir_root():
+    return DATA_DIR
+
+
+@pytest.fixture(params=INIFILES.keys(), ids=INIFILES.values())
+def inifile_root(request):
+    return request.param
+
+
+def pytest_report_header(config, start_path):
+    if sys.version_info >= (3, 13):
+        is_gil_enabled = sys._is_gil_enabled()
+    else:
+        is_gil_enabled = True
+
+    return [
+        f"{is_gil_enabled = }",
+    ]


### PR DESCRIPTION
Fix a packaging mistake I made in 6.0.0 which makes the source distribution untestable in isolation.