### PR TITLE
REL: systematically test source distribution in isolation before publication

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,8 @@ on:
     paths:
     - .github/workflows/cd.yml
     - README.md
-    - pyproject.toml
+    - ./**/pyproject.toml
+    - ./**/conftest.py
 
 jobs:
   pre-publish-checks:
@@ -19,15 +20,9 @@ jobs:
     - uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
     - run: uv run scripts/pre_publish_checks.py
 
-  pypi-publish:
-    name: Upload release to PyPI
-    needs: [pre-publish-checks]
+  build:
+    name: Build artifacts
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/inifix
-    permissions:
-      id-token: write
     steps:
     - name: Checkout Source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -35,7 +30,44 @@ jobs:
     - name: Build distributions
       shell: bash -l {0}
       run: uv build --package inifix
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      with:
+        name: artifacts
+        path: dist
 
+  test-sdist:
+    name: Test source distribution
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
+    - run: uv sync --only-group test
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        name: artifacts
+        path: dist
+    - name: test source distribution in isolation
+      run: |
+        tar xzf dist/*.tar.gz
+        cd inifix-*
+        uv pip install .
+        uv run --no-project pytest --color=yes -ra
+
+  pypi-publish:
+    name: Publish
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [pre-publish-checks, test-sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/inifix
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      with:
+        pattern: dist
     - name: Publish package distributions to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4


### PR DESCRIPTION
Prevent the mistake I made with version 6.0.0 (#379) from happening again.