### PR TITLE
BLD: switch build backend to flit-core on `inifix-cli`

### DIFF
--- a/lib/inifix/CHANGELOG.md
+++ b/lib/inifix/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+BLD: use a minimal build backend (`flit-core`) for `inifix-cli`. This only
+affects installing the repo's pre-commit hooks, and should reduce the chance of
+it breaking without maintenance.
+
 ## [6.0.1] - 2025-02-05
 
 BLD: ensure `conftest.py` is included in source distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "inifix-cli"


### PR DESCRIPTION
flit-core is sufficient here and seems a lot less suceptible to bitrot: 0 dependencies, and proper version pinning recommended in docs. Since inifix-cli is intended to be installed from source via pre-commit, this seems more important than migrating the core library.