### PR TITLE
RFC: simplify choice logic around sections arguments on the CLI using typer 0.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "exceptiongroup>=1.0.0", # TDOO: remove when support for Python 3.10 is dropped
+    "exceptiongroup>=1.0.0", # TODO: remove when support for Python 3.10 is dropped
     "inifix==6.1.1",
-    "typer-slim>=0.15.1",
+    "typer-slim>=0.19.0",
 ]
 
 [project.license]

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ typecheck = [
 requires-dist = [
     { name = "exceptiongroup", specifier = ">=1.0.0" },
     { name = "inifix", editable = "lib/inifix" },
-    { name = "typer-slim", specifier = ">=0.15.1" },
+    { name = "typer-slim", specifier = ">=0.19.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
This should not have user observable effects other than requiring more recent versions of typer, so a release is not mandated.