### PR TITLE
ENH: auto exclude some known incompatible ini files from validation and formatting commands by default, add support for overrides and extensions to the default exclude list

### DIFF
--- a/lib/inifix/CHANGELOG.md
+++ b/lib/inifix/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - DEP: support for Python 3.10 has been dropped
+- ENH: (pre-commit hooks) add ability to exclude files by regular expressions after
+  pre-commit's own selection via the new `--exclude` and `--extend-exclude` options.
+  The default exclude list is `['pytest\\.ini$', 'tox\\.ini$']`
 
 ## [6.1.2] - 2026-04-01
 
@@ -14,10 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TST: add support for CPython 3.15 (alpha)
 - TST: ensure utf-8 encoding is explicitly used everywhere
 - TYP: add preliminary support for type-checking with `ty`
-- ENH: (pre-commit hook) in CPython 3.15 and newer, `inifix format --diff`'s
+- ENH: (pre-commit hooks) in CPython 3.15 and newer, `inifix format --diff`'s
   output will now use color by default (unless `NO_COLOR=1` is set)
-- ENH: (pre-commit hook) add a `--no-color` flag to `inifix format`
-- DEP: (pre-commit hook) drop dependency on `typer`, use `click` directly instead
+- ENH: (pre-commit hooks) add a `--no-color` flag to `inifix format`
+- DEP: (pre-commit hooks) drop dependency on `typer`, use `click` directly instead
 - DOC: fix incorrect language spec for py-console code blocks
 - DOC: add badge showing Python versions supported in the most recent release
 

--- a/lib/inifix/README.md
+++ b/lib/inifix/README.md
@@ -371,3 +371,9 @@ It is possible to override this expression as, e.g.,
    - id: inifix-format
 +    files: (\.ini|\.par)$
 ```
+
+For convenience, in cases where the appropriate regular expression is hard to write,
+for instance if your project contains some files with a `.ini` extension that are not
+intended to be used with idefix, you may refine the selection via exclude patterns,
+using `--exclude` and/or `--extend-exclude`. By default, files named `pytest.ini` or
+`tox.ini` are excluded.

--- a/src/inifix_cli/__init__.py
+++ b/src/inifix_cli/__init__.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Literal, NewType, Callable, Any, IO, final, ca
 import click
 from textwrap import indent
 import inifix
+import re
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -82,17 +83,48 @@ class SectionsArg(Enum):
     require = auto()
 
 
+BUILTIN_EXCLUDES = [
+    r"pytest\.ini$",
+    r"tox\.ini$",
+]
+
+
+def filter_files(files: list[str], /, *, exclude: list[str] | None = None) -> list[str]:
+    exclude = exclude or []
+    return sorted(filter(lambda f: not any(re.search(p, f) for p in exclude), files))
+
+
 @app.command()
 @click.argument("files", nargs=-1, type=click.Path())
+@click.option(
+    "--exclude",
+    multiple=True,
+    default=BUILTIN_EXCLUDES,
+    help=(
+        "Override the default list of file names to exclude (as regular expressions). Multi-allowed. "
+        f"Default: {BUILTIN_EXCLUDES}"
+    ),
+)
+@click.option(
+    "--extend-exclude",
+    multiple=True,
+    help="Extend the list of file names to exclude (as regular expressions). Multi-allowed.",
+)
 @click.option(
     "--sections",
     type=click.Choice(SectionsArg, case_sensitive=True),
     default="allow",
 )
-def validate(files: list[str], sections: SectionsArg) -> None:
+def validate(
+    files: list[str],
+    exclude: list[str],
+    extend_exclude: list[str],
+    sections: SectionsArg,
+) -> None:
     """
     Validate files as inifix format-compliant.
     """
+    files = filter_files(files, exclude=exclude + extend_exclude)
     run_as_pool(partial(_validate_single_file, sections=sections), files)
 
 
@@ -123,6 +155,20 @@ def _validate_single_file(file: str, sections: SectionsArg) -> TaskResults:
 @app.command()
 @click.argument("files", nargs=-1, type=click.Path())
 @click.option(
+    "--exclude",
+    multiple=True,
+    default=BUILTIN_EXCLUDES,
+    help=(
+        "Override the default list of file names to exclude (as regular expressions). Multi-allowed. "
+        f"Default: {BUILTIN_EXCLUDES}"
+    ),
+)
+@click.option(
+    "--extend-exclude",
+    multiple=True,
+    help="Extend the list of file names to exclude (as regular expressions). Multi-allowed.",
+)
+@click.option(
     "--sections",
     type=click.Choice(SectionsArg, case_sensitive=True),
     default="allow",
@@ -149,6 +195,8 @@ def _validate_single_file(file: str, sections: SectionsArg) -> TaskResults:
 )
 def format(
     files: list[str],
+    exclude: list[str],
+    extend_exclude: list[str],
     sections: SectionsArg,
     diff: bool,
     no_color: bool,
@@ -158,6 +206,7 @@ def format(
     """
     Format files.
     """
+    files = filter_files(files, exclude=exclude + extend_exclude)
     run_as_pool(
         partial(
             _format_single_file,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,13 +4,14 @@ import textwrap
 from difflib import unified_diff
 from pathlib import Path
 from stat import S_IREAD
+from uuid import uuid4
 
 import click.testing
 import pytest
 
 import inifix
 import inifix_cli
-from inifix_cli import app
+from inifix_cli import BUILTIN_EXCLUDES, app
 
 runner = click.testing.CliRunner()
 N_FILES = 257
@@ -61,6 +62,34 @@ def assert_text_equal(actual: str, desired: str):
 
 def assert_text_includes(actual, desired):
     assert wrap(desired) in wrap(desired)
+
+
+def test_filter_files_default(tmp_path):
+    target = tmp_path / str(uuid4())
+    target.touch()
+    assert inifix_cli.filter_files([str(target)]) == [str(target)]
+
+
+@pytest.mark.parametrize(
+    "names, exclude, expected_names",
+    [
+        pytest.param(["a.ini"], ["a.*"], [], id="exclude-only-files"),
+        pytest.param(["a.ini", "b.cfg"], [r"\.ini$"], ["b.cfg"], id="exclude-partial"),
+        pytest.param(
+            ["pytest.ini", "tox.ini"], BUILTIN_EXCLUDES, [], id="default-excludes"
+        ),
+    ],
+)
+def test_filter_files_exclude(names, exclude, expected_names, tmp_path):
+    targets = [tmp_path / name for name in names]
+    for t in targets:
+        t.touch()
+
+    expected = [str(t) for t in targets if t.name in expected_names]
+    assert len(expected) == len(expected_names)
+    assert (
+        inifix_cli.filter_files([str(t) for t in targets], exclude=exclude) == expected
+    )
 
 
 class TestValidate:
@@ -220,6 +249,16 @@ class TestFormat:
             result.stdout,
             f"Error: could not write to {target} (permission denied)\n",
         )
+
+    @pytest.mark.parametrize("name", ["pytest.ini", "tox.ini"])
+    @pytest.mark.parametrize("cmd", ["validate", "format"])
+    def test_exclude_defaults(self, name, cmd, tmp_path):
+        target = tmp_path / name
+        target.write_text("Invalid data, should be ignored", encoding="utf-8")
+        result = runner.invoke(app, [cmd, str(target)])
+        assert result.exit_code == 0
+        assert result.stderr == ""
+        assert result.stdout == ""
 
     def test_diff_stdout(self, inifile_root, tmp_path):
         target = tmp_path / inifile_root.name


### PR DESCRIPTION
close #508 

TODO:
- [x] changelog
- [x] tests
- [x] doc