### PR TITLE
TYP: ignore a couple begnin reports from pyrefly

### DIFF
--- a/cli/inifix-cli/src/inifix_cli/__init__.py
+++ b/cli/inifix-cli/src/inifix_cli/__init__.py
@@ -62,11 +62,11 @@ class Exit(click.ClickException):
 
     # TODO: from typing import override (requires Python 3.12)
     # @override
-    def __init__(self) -> None:
-        super().__init__("")
+    def __init__(self, message: str = "") -> None:
+        super().__init__(message)
 
     # @override
-    def show(self, file: IO[Any] | None = None) -> None: ...  # pyright: ignore[reportExplicitAny, reportImplicitOverride]
+    def show(self, file: IO[Any] | None = None) -> None: ...  # pyright: ignore[reportExplicitAny, reportImplicitOverride] # pyrefly: ignore[missing-override-decorator]
 
 
 def run_as_pool(closure: Callable[[str], TaskResults], files: list[str]) -> None:
@@ -284,7 +284,7 @@ def _format_single_file(
                 data.splitlines(),
                 fmted_data.splitlines(),
                 fromfile=file,
-                **diff_kwargs,  # pyright: ignore[reportUnknownArgumentType]
+                **diff_kwargs,  # pyright: ignore[reportUnknownArgumentType] # pyrefly: ignore[bad-argument-type]
             )
         )
         assert diff_


### PR DESCRIPTION
The errors I'm suppressing here are:
- one real (`missing-override-decorator`), but begnin and will wait for Python 3.11 to be dropped
- one very forgivable false positive in a case where the code is probably too dynamic for static analysis. It's also temporary and very short, so it's fine.

checked with
```shell
uvx 'pyrefly==1.1.0.dev1' check ./**/src --preset=strict
```
The only remaining error after that is a false positive already reported upstream and listed in https://github.com/neutrinoceros/inifix/pull/507