### PR TITLE
RFC/TYP: invert branching condition in a helper function

### DIFF
--- a/src/inifix/_io.py
+++ b/src/inifix/_io.py
@@ -38,10 +38,10 @@ def _always_iterable(obj: Scalar | Sequence[Scalar], /) -> Iterator[Scalar]:
     if isinstance(obj, str):
         return iter((obj,))
 
-    if isinstance(obj, Sequence):
-        return iter(obj)
-    else:
+    if isinstance(obj, Scalar):
         return iter((obj,))
+    else:
+        return iter(obj)
 
 
 def _is_numeric(s: str) -> bool:


### PR DESCRIPTION
The original code is flagged by `ty`:

```
error[invalid-return-type]: Return type does not match returned value
  --> src/inifix/_io.py:42:16
   |
42 |         return iter(obj)
   |                ^^^^^^^^^ expected `Iterator[int | float | str]`, found `Iterator[object]`
   |
  ::: src/inifix/_io.py:36:60
   |
36 | def _always_iterable(obj: Scalar | Sequence[Scalar], /) -> Iterator[Scalar]:
   |                                                            ---------------- Expected `Iterator[int | float | str]` because of return type
   |
info: protocol `Iterator[object]` is not assignable to protocol `Iterator[int | float | str]`
info: └── protocol member `__next__` is incompatible
info:     └── incompatible return types: `object` is not assignable to `int | float | str`
```

supposedly, this happens because `Sequence` and `int` aren't disjoint bases.
I'm a bit out of my depth here but the refactor passes checks.